### PR TITLE
Fix updating task name when clearing task from card.

### DIFF
--- a/src/report.ts
+++ b/src/report.ts
@@ -63,6 +63,11 @@ export default () => {
   t.render(() =>
     TrelloPromise.all([getTask(t), getProjectId(t)]).then(
       async ([task, projectId]) => {
+        const taskName = document.getElementById('harvestTaskName');
+        /* istanbul ignore else */
+        if (taskName) {
+          taskName.innerHTML = task ? task.name : 'not set';
+        }
         const container = document.getElementById('reportContainer');
         if (!task || !container) {
           if (container) {
@@ -70,11 +75,6 @@ export default () => {
           }
           t.sizeTo('#allContainer');
           return;
-        }
-        const taskName = document.getElementById('harvestTaskName');
-        /* istanbul ignore else */
-        if (taskName) {
-          taskName.innerHTML = task.name;
         }
         const table = document.createElement('table');
         const data: TimeEntriesData = await getHarvestJSON(


### PR DESCRIPTION

![](https://www.thesprucepets.com/thmb/3EeXwbgZcB42tkEYe8z0iX-EemA=/960x0/filters:no_upscale():max_bytes(150000):strip_icc()/animal-cute-fox-271904-5bbe8f0ec9e77c0058dd1d23.jpg)

## Description

Ran into this minor bug while working on fixing time summaries. If you clear a task from a card, it wasn't removing the previous task name from the "time report" card section. So I fixed it.

## Steps to test/reproduce

Open a card with a task assigned to it, edit the assigned task and choose `--clear--`. The time-report card section should update to say "The Harvest task for this card is not set." Before this fix it wouldn't update, it would still say "The Harvest task for this card is previously-assigned-task." (The time report always did update, just not the task name.)

---

## Reviewer tasks:

You're welcome to pull the code locally to verify the fix if you want, but given the fix is small and it's kind of a hassle to set up Oddvest for local dev, I think you could just trust my manual testing and just review the code :)

- [x] Reviewed code
